### PR TITLE
Using HTMLParser to parse any entities retrieved by the api

### DIFF
--- a/server/assistant/skills/newyddion/newyddion.py
+++ b/server/assistant/skills/newyddion/newyddion.py
@@ -6,11 +6,13 @@ from Skill import Skill
 
 from padatious import IntentContainer
 
+from html.parser import HTMLParser
+
+
 class newyddion_skill(Skill):
 
     def __init__(self, root_dir, name, nlp, active):
         super(newyddion_skill, self).__init__(root_dir, name, nlp, active)
-
 
     def handle(self, intent_parser_result, latitude, longitude):
 
@@ -22,27 +24,28 @@ class newyddion_skill(Skill):
 
         if 'subject' in context.keys():
             subject = context["subject"]
-            subject = subject.replace('?','')
+            subject = subject.replace('?', '')
             rss_url = rss_url % subject
             title = "Dyma benawdau %s gwefan newyddion Golwg 360" % subject
-        else: 
+        else:
             rss_url = rss_url % 'newyddion'
             title = "Dyma benawdau gwefan newyddion Golwg 360"
 
         title = title + "."
 
-        skill_response.append({ 
-            'title' : title,
-            'description' : '',
-            'url' : ''})
+        skill_response.append({
+            'title': title,
+            'description': '',
+            'url': ''})
+
+        html_parser = HTMLParser()
 
         rss = feedparser.parse(rss_url)
         for entry in rss.get("entries")[:5]:
             skill_response.append({
-                'title' : entry.get("title") + ".", 
-                'description' : entry.get('description') + ".", 
-                'url' : entry.get('link')
-            }) 
+                'title': html_parser.unescape(entry.get("title") + "."),
+                'description': html_parser.unescape(entry.get('description') + "."),
+                'url': entry.get('link')
+            })
 
         return skill_response
-        

--- a/server/assistant/skills/newyddion/newyddion.py
+++ b/server/assistant/skills/newyddion/newyddion.py
@@ -11,6 +11,8 @@ from html.parser import HTMLParser
 
 class newyddion_skill(Skill):
 
+    html_parser = HTMLParser()
+
     def __init__(self, root_dir, name, nlp, active):
         super(newyddion_skill, self).__init__(root_dir, name, nlp, active)
 
@@ -37,8 +39,6 @@ class newyddion_skill(Skill):
             'title': title,
             'description': '',
             'url': ''})
-
-        html_parser = HTMLParser()
 
         rss = feedparser.parse(rss_url)
         for entry in rss.get("entries")[:5]:


### PR DESCRIPTION
Tested the functionality of using `unescaped` and it does successfully convert `&#8217` to ` '`; however I cannot test this with the API locally due to the issues mentioned in https://github.com/techiaith/macsen-sgwrsfot/issues/3 . So until I, or someone else, can test this using the API I'm setting the PR to be a draft.